### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,6 +1,8 @@
 # https://cpp-linter.github.io/cpp-linter-action/
 
 name: CI
+permissions:
+    contents: read
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Potential fix for [https://github.com/PurifyMyWater/SettingsStorageLib/security/code-scanning/1](https://github.com/PurifyMyWater/SettingsStorageLib/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow file to restrict the GITHUB_TOKEN permissions to the minimum required. Since none of the jobs shown require write access to repository contents, the best fix is to add `permissions: contents: read` at the root level of the workflow, which will apply to all jobs unless overridden. This should be added after the `name: CI` block and before the `concurrency:` block (or immediately after `name:` if you prefer). No additional imports or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
