### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,6 +1,8 @@
 # https://cpp-linter.github.io/cpp-linter-action/
 
 name: CI
+permissions:
+    contents: read
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Potential fix for [https://github.com/PurifyMyWater/SettingsStorageLib/security/code-scanning/2](https://github.com/PurifyMyWater/SettingsStorageLib/security/code-scanning/2)

To fix the problem, you should add a `permissions` block to the workflow file `.github/workflows/CI.yml`. The block can be added at the top level (applies to all jobs unless overridden) or to individual jobs if different jobs require different permissions. The minimal starting point is `contents: read`, which allows jobs to read repository contents but not write. If any job requires additional permissions (such as writing to pull requests), you can add those as needed. For this fix, add the following block after the `name: CI` line and before `concurrency:`:

```yaml
permissions:
  contents: read
```

This ensures that all jobs in the workflow only have read access to repository contents unless explicitly overridden.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
