### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -167,6 +167,8 @@ jobs:
             BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory # Directory where build-wrapper output will be placed
             GH_PAT: ${{ secrets.PMW_CI_PAT }}
             GH_USER_NAME: vacmg
+        permissions:
+            contents: read
 
         steps:
             -   name: Restore cached Coverage Report


### PR DESCRIPTION
Potential fix for [https://github.com/PurifyMyWater/SettingsStorageLib/security/code-scanning/4](https://github.com/PurifyMyWater/SettingsStorageLib/security/code-scanning/4)

To fix the problem, add an explicit `permissions` block to the `Sonar` job in `.github/workflows/CI.yml`. This block should restrict the permissions of the `GITHUB_TOKEN` to the minimum required for the job to function. Since the job does not appear to need write access to repository contents, the recommended minimal permission is `contents: read`. The `permissions` block should be added directly under the `Sonar:` job definition, before the `steps:` key (ideally after `env:` if present). No other changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
