### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -83,6 +83,8 @@ jobs:
     Valgrind:
         runs-on: ubuntu-latest
         needs: Build
+        permissions:
+            contents: read
 
         steps:
             -   name: Install Valgrind tool


### PR DESCRIPTION
Potential fix for [https://github.com/PurifyMyWater/SettingsStorageLib/security/code-scanning/3](https://github.com/PurifyMyWater/SettingsStorageLib/security/code-scanning/3)

To fix the problem, we should add a `permissions` block to the `Valgrind` job in `.github/workflows/CI.yml` to restrict the GITHUB_TOKEN permissions to the minimum required. Since the job only needs to check out code and interact with caches, it does not require write access to repository contents or other resources. The minimal required permission is `contents: read`. This change should be made by adding the following block under the `Valgrind:` job definition, at the same indentation level as `runs-on`, `needs`, and `steps`:

```yaml
permissions:
    contents: read
```

No additional imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
